### PR TITLE
 Use NULL as zeroTime in wait()

### DIFF
--- a/aio.go
+++ b/aio.go
@@ -281,8 +281,13 @@ func (a *AIO) wait(to timespec, completed []RequestId) (int, error) {
 		return 0, nil
 	}
 
+	toPtr := uintptr(unsafe.Pointer(&to))
+	if to == zeroTime {
+		toPtr = 0
+	}
+
 	//wait for at least one active request to complete
-	x, _, ret := syscall.Syscall6(syscall.SYS_IO_GETEVENTS, uintptr(a.ctx), uintptr(1), uintptr(len(a.active)), uintptr(unsafe.Pointer(&a.evt[0])), uintptr(unsafe.Pointer(&to)), uintptr(0))
+	x, _, ret := syscall.Syscall6(syscall.SYS_IO_GETEVENTS, uintptr(a.ctx), uintptr(1), uintptr(len(a.active)), uintptr(unsafe.Pointer(&a.evt[0])), toPtr, uintptr(0))
 	if ret != 0 {
 		return 0, errLookup(ret)
 	}


### PR DESCRIPTION
WaitFor() after ReadAt() was failing for me without this fix on Ubuntu 20.04.

io_getevents() man page says: "Specifying timeout as NULL means block indefinitely until at least min_nr events have been obtained."
https://man7.org/linux/man-pages/man2/io_getevents.2.html

According to the code comment that seems to be what is needed:
```
//wait for at least one active request to complete
x, _, ret := syscall.Syscall6(syscall.SYS_IO_GETEVENTS, uintptr(a.ctx), uintptr(1), uintptr(len(a.active)), uintptr(unsafe.Pointer(&a.evt[0])), uintptr(unsafe.Pointer(&to)), uintptr(0))
```